### PR TITLE
Update lib/tests/3.2.5.js

### DIFF
--- a/lib/tests/3.2.5.js
+++ b/lib/tests/3.2.5.js
@@ -116,7 +116,7 @@ describe("3.2.5: `then` may be called multiple times on the same promise.", func
         });
     });
 
-    describe("3.2.5.1: If/when `promise` is rejected, respective `onRejected` callbacks must execute in the order " +
+    describe("3.2.5.2: If/when `promise` is rejected, respective `onRejected` callbacks must execute in the order " +
              "of their originating calls to `then`.", function () {
         describe("multiple boring rejection handlers", function () {
             testRejected(sentinel, function (promise, done) {


### PR DESCRIPTION
Minor naming issue. Your rejected tests for multiple then() calls had the reference 3.2.5.1 but that is actually the reference for fulfilled. 3.2.5.2 is the correct number for rejected
