### PR TITLE
Fixes test 3.2.6 by allowing promises to be functions

### DIFF
--- a/lib/tests/3.2.6.js
+++ b/lib/tests/3.2.6.js
@@ -17,7 +17,7 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
         var promise1 = pending().promise;
         var promise2 = promise1.then();
 
-        assert.strictEqual(typeof promise2, "object");
+        assert(typeof promise2 === "object" || typeof promise2 === "function", "promise2 is neither object nor function");
         assert.notStrictEqual(promise2, null);
         assert.strictEqual(typeof promise2.then, "function");
     });


### PR DESCRIPTION
Patch fixes test 3.2.6 by allowing promises to be either functions or objects.
