### PR TITLE
Test returnedPromise fulfilled/rejected with a promise

### DIFF
--- a/lib/tests/3.2.6.js
+++ b/lib/tests/3.2.6.js
@@ -11,6 +11,7 @@ var pending = adapter.pending;
 
 var dummy = { dummy: "dummy" }; // we fulfill or reject with this when we don't intend to test against it
 var sentinel = { sentinel: "sentinel" }; // a sentinel fulfillment value to test for with strict equality
+var sentinelPromise = fulfilled(dummy);
 var other = { other: "other" }; // a value we don't want to be strict equal to
 
 describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfilled, onRejected)`", function () {
@@ -182,6 +183,20 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
                         done();
                     });
                 });
+
+                specify("a pseudo-promise which pass a promise to callback function", function (done) {
+                    var promise1 = fulfilled(dummy);
+                    var promise2 = promise1.then(function onFulfilled() {
+                        return {
+                            then: function (f) { f(sentinelPromise); }
+                        };
+                    });
+
+                    promise2.then(function onPromise2Fulfilled(value) {
+                        assert.strictEqual(value, sentinelPromise);
+                        done();
+                    });
+                });
             });
             describe("`promise1` is rejected, and `returnedPromise` is:", function () {
                 testFulfilled(sentinel, function (returnedPromise, done) {
@@ -206,6 +221,20 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
 
                     promise2.then(function onPromise2Fulfilled(value) {
                         assert.strictEqual(value, sentinel);
+                        done();
+                    });
+                });
+
+                specify("a pseudo-promise which pass a promise to callback function", function (done) {
+                    var promise1 = rejected(dummy);
+                    var promise2 = promise1.then(null, function onRejected() {
+                        return {
+                            then: function (f) { f(sentinelPromise); }
+                        };
+                    });
+
+                    promise2.then(function onPromise2Fulfilled(value) {
+                        assert.strictEqual(value, sentinelPromise);
                         done();
                     });
                 });
@@ -240,6 +269,20 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
                         done();
                     });
                 });
+
+                specify("a pseudo-promise which pass a promise to callback function", function (done) {
+                    var promise1 = fulfilled(dummy);
+                    var promise2 = promise1.then(function onFulfilled() {
+                        return {
+                            then: function (f, r) { r(sentinelPromise); }
+                        };
+                    });
+
+                    promise2.then(null, function onPromise2Fulfilled(value) {
+                        assert.strictEqual(value, sentinelPromise);
+                        done();
+                    });
+                });
             });
             describe("`promise1` is rejected, and `returnedPromise` is:", function () {
                 testRejected(sentinel, function (returnedPromise, done) {
@@ -264,6 +307,20 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
 
                     promise2.then(null, function onPromise2Rejected(reason) {
                         assert.strictEqual(reason, sentinel);
+                        done();
+                    });
+                });
+
+                specify("a pseudo-promise which pass a promise to callback function", function (done) {
+                    var promise1 = rejected(dummy);
+                    var promise2 = promise1.then(null, function onFulfilled() {
+                        return {
+                            then: function (f, r) { r(sentinelPromise); }
+                        };
+                    });
+
+                    promise2.then(null, function onPromise2Fulfilled(value) {
+                        assert.strictEqual(value, sentinelPromise);
                         done();
                     });
                 });


### PR DESCRIPTION
Hello.

I develop a Promises/A+ library [Ten.Promise](https://github.com/nobuoka/Ten.Promise), which aims to have interface-level compatibility with [WinJS.Promise](http://msdn.microsoft.com/en-us/library/windows/apps/br211867.aspx).

Now, my library Ten.Promise is different from WinJS.Promise in treatment of a returnedPromise fulfilled/rejected with a promise.

``` JavaScript
var sentinel = {};
var sentinelPromise = Promise.wrap(sentinel);

// `p` is a fulfilled promise
var p = Promise.wrap(100);

// a pseudo promise which pass a promise to callback functions
var pseudoPromObj = {
    then: function (s) {
        s(sentinelPromise);
    }
};

var p2 = p.then(function () {
    return pseudoPromObj;
});
p2.then(function (val) {
    // Here is difference:
    //   `val` is `sentinel` in case of using WinJS.Promise,
    //   while `val` is `sentinelPromise` in case of using Ten.Promise
});
```

I think Ten.Promise is compliant to the Promises/A+ specification. However, either implementation passes the current promises-tests, so I added tests about this behavior to promises-tests.

Thanks.
