### PR TITLE
Add mocha programmatic function

### DIFF
--- a/lib/programmaticRunner.js
+++ b/lib/programmaticRunner.js
@@ -54,3 +54,33 @@ module.exports = function (adapter, cb) {
         });
     });
 };
+
+module.exports.mocha = function (adapter) {
+    if (!adapter.fulfilled) {
+        adapter.fulfilled = function (value) {
+            var tuple = adapter.pending();
+            tuple.fulfill(value);
+            return tuple.promise;
+        };
+    }
+
+    if (!adapter.rejected) {
+        adapter.rejected = function (reason) {
+            var tuple = adapter.pending();
+            tuple.reject(reason);
+            return tuple.promise;
+        };
+    }
+    
+    global.adapter = adapter;
+
+    var testsDir = path.resolve(__dirname, "tests");
+
+    testFileNames = fs.readdirSync(testsDir);
+    testFileNames.forEach(function (testFileName) {
+        if (path.extname(testFileName) === ".js") {
+            var testFilePath = path.resolve(testsDir, testFileName);
+            require(testFilePath);
+        }
+    });
+}


### PR DESCRIPTION
Useful for people who already use mocha as their test runner.  It allows you to just do:

``` js
describe('promises-tests', function () {
  require('promises-aplus-tests').mocha(adapter);
});
```

at the end of a mocha test file and have everything work perfectly, complete with all the command line options that mocha supports.
