### PR TITLE
Print the error encountered requiring the adapter.

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -43,6 +43,6 @@ function adapterObjectFromFilePath(filePath) {
     try {
         return require(filePath);
     } catch (e) {
-        throw new Error("Error `require`ing adapter file " + filePath);
+        throw new Error("Error `require`ing adapter file " + filePath + ": " + e);
     }
 }


### PR DESCRIPTION
I'm trying to debug a [Travis build failure](https://travis-ci.org/tildeio/rsvp.js/builds/5329787) that is passing just fine locally. Without exactly what went wrong requiring the file it's pretty hard to figure out.
