### PR TITLE
Use JS terminology for the result of `pending` in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ modules with a few well-known exports:
 
 - `fulfilled(value)`: creates a promise that is already fulfilled with `value`.
 - `rejected(reason)`: creates a promise that is already rejected with `reason`.
-- `pending()`: creates a tuple consisting of `{ promise, fulfill, reject }`:
+- `pending()`: creates an Object consisting of `{ promise: Promise, fulfill: Function, reject: Function }`:
   - `promise` is a promise object that is currently in the pending state.
   - `fulfill(value)` moves the promise from the pending state to a fulfilled state, with fulfillment value `value`.
   - `reject(reason)` moves the promise from the pending state to the rejected state, with rejection reason `reason`.


### PR DESCRIPTION
It's really weird to say that `pending()` should return a Tuple in JavaScript. The language has no concepts of Tuples, and when you say "it should return a Tuple of `{ promise, fulfill, reject }`" I immediately think about a Haskell Tuple, which would be `( promise, fulfill, reject )`, and close to the JS idiom `[ promise, fulfill, reject ]`.

This, as it turns out, is quite unintuitive for people who are used to the concept of tuples (and working with them in other languages like Haskell or Python), who will have their `pending` function return such List, just to find out quite a while afterwards that you should actually be returning an Object, as I've discovered from reading @briancavalier's avow tests (https://github.com/briancavalier/avow/blob/master/test/avow-adapter.js#L4-L11)
