### PR TITLE
rejection should call second callback, not first

### DIFF
--- a/lib/tests/3.2.6.js
+++ b/lib/tests/3.2.6.js
@@ -42,7 +42,7 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
                         return expectedValue;
                     });
 
-                    promise2.then(null, function onPromise2Fulfilled(actualValue) {
+                    promise2.then(null, function onPromise2Rejected(actualValue) {
                         assert.strictEqual(actualValue, expectedValue);
                         done();
                     });


### PR DESCRIPTION
This test checks if callback is called, but since it is on the rejection chain, it should call the 2nd callback
