### PR TITLE
when a promise is rejected, all chain should reject

### DIFF
--- a/lib/tests/3.2.6.js
+++ b/lib/tests/3.2.6.js
@@ -148,7 +148,7 @@ describe("3.2.6: `then` must return a promise: `promise2 = promise1.then(onFulfi
 
                 setTimeout(function () {
                     assert.strictEqual(wasFulfilled, false);
-                    assert.strictEqual(wasRejected, false);
+                    assert.strictEqual(wasRejected, true);
                     done();
                 }, 100);
             });


### PR DESCRIPTION
Since original promise was rejected, all the following promises in the chain would be rejected, thus none should stay pending
