### PR TITLE
Allowing the spy names to be more descriptive

### DIFF
--- a/lib/tests/3.2.5.js
+++ b/lib/tests/3.2.5.js
@@ -100,9 +100,9 @@ describe("3.2.5: `then` may be called multiple times on the same promise.", func
 
         describe("`onFulfilled` handlers are called in the original order", function () {
             testFulfilled(dummy, function (promise, done) {
-                var handler1 = sinon.spy();
-                var handler2 = sinon.spy();
-                var handler3 = sinon.spy();
+                var handler1 = sinon.spy(function handler1() {});
+                var handler2 = sinon.spy(function handler2() {});
+                var handler3 = sinon.spy(function handler3() {});
 
                 promise.then(handler1);
                 promise.then(handler2);
@@ -116,9 +116,9 @@ describe("3.2.5: `then` may be called multiple times on the same promise.", func
 
             describe("even when one handler is added inside another handler", function () {
                 testFulfilled(dummy, function (promise, done) {
-                    var handler1 = sinon.spy();
-                    var handler2 = sinon.spy();
-                    var handler3 = sinon.spy();
+                    var handler1 = sinon.spy(function handler1() {});
+                    var handler2 = sinon.spy(function handler2() {});
+                    var handler3 = sinon.spy(function handler3() {});
 
                     promise.then(function () {
                         handler1();
@@ -217,9 +217,9 @@ describe("3.2.5: `then` may be called multiple times on the same promise.", func
 
         describe("`onRejected` handlers are called in the original order", function () {
             testRejected(dummy, function (promise, done) {
-                var handler1 = sinon.spy();
-                var handler2 = sinon.spy();
-                var handler3 = sinon.spy();
+                var handler1 = sinon.spy(function handler1() {});
+                var handler2 = sinon.spy(function handler2() {});
+                var handler3 = sinon.spy(function handler3() {});
 
                 promise.then(null, handler1);
                 promise.then(null, handler2);
@@ -233,9 +233,9 @@ describe("3.2.5: `then` may be called multiple times on the same promise.", func
 
             describe("even when one handler is added inside another handler", function () {
                 testRejected(dummy, function (promise, done) {
-                    var handler1 = sinon.spy();
-                    var handler2 = sinon.spy();
-                    var handler3 = sinon.spy();
+                    var handler1 = sinon.spy(function handler1() {});
+                    var handler2 = sinon.spy(function handler2() {});
+                    var handler3 = sinon.spy(function handler3() {});
 
                     promise.then(null, function () {
                         handler1();


### PR DESCRIPTION
This changes the error from

```
AssertError: expected spy, spy, spy to be called in order but were called as spy, spy, spy
```

to a far more useful

```
AssertError: expected handler1, handler2, handler3 to be called in order but were called as handler1, handler3, handler2
```
