### PR TITLE
Test for whatever `this` values are actually given in the environment

### DIFF
--- a/lib/tests/2.2.5.js
+++ b/lib/tests/2.2.5.js
@@ -8,13 +8,22 @@ var rejected = adapter.rejected;
 
 var dummy = { dummy: "dummy" }; // we fulfill or reject with this when we don't intend to test against it
 
+var undefinedThisStrict = (function() {
+    "use strict";
+    return this;
+})();
+
+var undefinedThisSloppy = (function() {
+    return this;
+})();
+
 describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e. with no `this` value).", function () {
     describe("strict mode", function () {
         specify("fulfilled", function (done) {
             resolved(dummy).then(function onFulfilled() {
                 "use strict";
 
-                assert.strictEqual(this, undefined);
+                assert.strictEqual(this, undefinedThisStrict);
                 done();
             });
         });
@@ -23,7 +32,7 @@ describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e.
             rejected(dummy).then(null, function onRejected() {
                 "use strict";
 
-                assert.strictEqual(this, undefined);
+                assert.strictEqual(this, undefinedThisStrict);
                 done();
             });
         });
@@ -32,14 +41,14 @@ describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e.
     describe("sloppy mode", function () {
         specify("fulfilled", function (done) {
             resolved(dummy).then(function onFulfilled() {
-                assert.strictEqual(this, global);
+                assert.strictEqual(this, undefinedThisSloppy);
                 done();
             });
         });
 
         specify("rejected", function (done) {
             rejected(dummy).then(null, function onRejected() {
-                assert.strictEqual(this, global);
+                assert.strictEqual(this, undefinedThisSloppy);
                 done();
             });
         });


### PR DESCRIPTION
I needed to do this when I created the browser version of tests for bluebird because e.g. ES3 browsers ignore `"use strict"` and would fail the hard coded comparison to `undefined`.

This instead detects at runtime for whatever value is given when a function that mentions `"use strict"` at the top is directly called.

It's probably more flexible than actually needed but yea.
