### PR TITLE
Workaround for erratic "use strict" behavior in PhantomJS.

### DIFF
--- a/lib/tests/2.2.5.js
+++ b/lib/tests/2.2.5.js
@@ -8,21 +8,16 @@ var rejected = adapter.rejected;
 
 var dummy = { dummy: "dummy" }; // we fulfill or reject with this when we don't intend to test against it
 
-// Make the tests tolerant of older environments which don't have the correct semantics for `this` in strict mode
-// (e.g. because they don't implement strict mode at all).
-
-var defaultThisStrict = (function () {
-    "use strict";
-    return this;
-}());
-
-var defaultThisSloppy = (function () {
-    return this;
-}());
-
 describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e. with no `this` value).", function () {
     describe("strict mode", function () {
         specify("fulfilled", function (done) {
+            // Make the tests tolerant of older environments which don't have the correct semantics for `this` in strict mode
+            // (e.g. because they don't implement strict mode at all).
+            var defaultThisStrict = (function () {
+                "use strict";
+                return this;
+            }());
+
             resolved(dummy).then(function onFulfilled() {
                 "use strict";
 
@@ -32,6 +27,11 @@ describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e.
         });
 
         specify("rejected", function (done) {
+            var defaultThisStrict = (function () {
+                "use strict";
+                return this;
+            }());
+
             rejected(dummy).then(null, function onRejected() {
                 "use strict";
 
@@ -43,6 +43,10 @@ describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e.
 
     describe("sloppy mode", function () {
         specify("fulfilled", function (done) {
+            var defaultThisSloppy = (function () {
+                return this;
+            }());
+
             resolved(dummy).then(function onFulfilled() {
                 assert.strictEqual(this, defaultThisSloppy);
                 done();
@@ -50,6 +54,10 @@ describe("2.2.5 `onFulfilled` and `onRejected` must be called as functions (i.e.
         });
 
         specify("rejected", function (done) {
+            var defaultThisSloppy = (function () {
+                return this;
+            }());
+
             rejected(dummy).then(null, function onRejected() {
                 assert.strictEqual(this, defaultThisSloppy);
                 done();


### PR DESCRIPTION
These changes ensure the expected scope is evaluated in the same context (i.e. within the same Mocha `specify()` block) in which the test onResolved or onRejected callback is created.

While I hate to introduce duplicated declarations of `defaultThisStrict` and `defaultThisSloppy` across these tests, it appears to be the only way to resolve this issue in the PhantomJS environment (which we for @DeftJS use in combination with Karma Test Runner and Travis CI).

Related to: stefanpenner@3a407b7
and: https://gist.github.com/stefanpenner/6d1ebcf2a6506914c831

Fixes #47
