### PR TITLE
fixed getMochaOpts() for no-arg options at the end of argv

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -29,7 +29,7 @@ function getMochaOpts() {
         var optSplit = opt.split(" ");
 
         var key = optSplit[0];
-        var value = optSplit[1] === "" ? true : optSplit[1];
+        var value = optSplit[1] || true;
 
         if (key) {
             opts[key] = value;


### PR DESCRIPTION
I noticed that the `--bail` option was ignored when I tried this:

```
promises-aplus-tests my_adapter.js --bail
```

From a quick glance at the code, it's clear this is because `bail.split(' ')[1]` is `undefined`, not an empty string. The fix to `getMochaOpts` is simple: check the 'value' of the option for falsiness rather than equality with `""`.

Now, some folks don't like PRs without tests. So I have two proposals: one is this PR, which is just the simple one-line fix. The other proposal is a separate PR, in which I also add some tests for the `getMochaOpts` method.

The downside to the PR with tests (#55), of course, is that it involves pulling the method out of cli.js to make it testable and sort of disrupts (in my opinion) what is otherwise a very clean, simple project structure.

Personally I don't have a preference between the two; but I wanted to offer both so you can choose between them.
