### PR TITLE
fixed getMochaOpts() and added tests

### DIFF
--- a/lib/cli.js
+++ b/lib/cli.js
@@ -2,11 +2,12 @@
 "use strict";
 
 var path = require("path");
+var getMochaOpts = require("./getMochaOpts");
 var programmaticRunner = require("./programmaticRunner");
 
 var filePath = getAdapterFilePath();
 var adapter = adapterObjectFromFilePath(filePath);
-var mochaOpts = getMochaOpts();
+var mochaOpts = getMochaOpts(process.argv.slice(3));
 programmaticRunner(adapter, mochaOpts, function (err) {
     if (err) {
         process.exit(err.failures || -1);
@@ -19,24 +20,6 @@ function getAdapterFilePath() {
     } else {
         throw new Error("Specify your adapter file as an argument.");
     }
-}
-
-function getMochaOpts() {
-    var rawOpts = process.argv.slice(3);
-    var opts = {};
-
-    rawOpts.join(" ").split("--").forEach(function (opt) {
-        var optSplit = opt.split(" ");
-
-        var key = optSplit[0];
-        var value = optSplit[1] || true;
-
-        if (key) {
-            opts[key] = value;
-        }
-    });
-
-    return opts;
 }
 
 function adapterObjectFromFilePath(filePath) {

--- a/lib/getMochaOpts.js
+++ b/lib/getMochaOpts.js
@@ -1,0 +1,19 @@
+"use strict";
+
+module.exports = function getMochaOpts(args) {
+    var rawOpts = args;
+    var opts = {};
+
+    rawOpts.join(" ").split("--").forEach(function (opt) {
+        var optSplit = opt.split(" ");
+
+        var key = optSplit[0];
+        var value = optSplit[1] || true;
+
+        if (key) {
+            opts[key] = value;
+        }
+    });
+
+    return opts;
+};

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
         "promises-aplus-tests": "lib/cli.js"
     },
     "scripts": {
-        "lint": "jshint lib"
+        "lint": "jshint lib",
+        "test": "mocha"
     },
     "dependencies": {
         "mocha": "~1.13.0",

--- a/test/getMochaOptsTest.js
+++ b/test/getMochaOptsTest.js
@@ -1,0 +1,30 @@
+var assert = require('assert');
+var getMochaOpts = require('../lib/getMochaOpts');
+
+describe('getMochaOpts', function() {
+  function test(args, expectedOpts) {
+    var opts = getMochaOpts(args.split(' '));
+    assert.deepEqual(opts, expectedOpts);
+  }
+
+  it('parses the provided options to an object', function() {
+    test('--reporter spec --ui bdd', {
+      reporter: 'spec',
+      ui: 'bdd'
+    });
+  });
+
+  it('sets the value for no-arg options to true', function() {
+    test('--bail --ui bdd', {
+      bail: true,
+      ui: 'bdd'
+    });
+  });
+
+  it('supports no-arg options as the last option', function() {
+    test('--reporter spec --bail', {
+      reporter: 'spec',
+      bail: true
+    });
+  });
+});


### PR DESCRIPTION
This is the same fix to `getMochaOpts` proposed in #54, but with tests (see the other PR for more info).
