### PR TITLE
Changed the numberOfTimesThenWasRetrieved to be added when 'then' is cal...

### DIFF
--- a/lib/tests/2.3.3.js
+++ b/lib/tests/2.3.3.js
@@ -132,8 +132,8 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 return Object.create(null, {
                     then: {
                         get: function () {
-                            ++numberOfTimesThenWasRetrieved;
                             return function thenMethodForX(onFulfilled) {
+                                ++numberOfTimesThenWasRetrieved;
                                 onFulfilled();
                             };
                         }
@@ -160,8 +160,8 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 return Object.create(Object.prototype, {
                     then: {
                         get: function () {
-                            ++numberOfTimesThenWasRetrieved;
                             return function thenMethodForX(onFulfilled) {
+                                ++numberOfTimesThenWasRetrieved;
                                 onFulfilled();
                             };
                         }
@@ -189,8 +189,8 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
 
                 Object.defineProperty(x, "then", {
                     get: function () {
-                        ++numberOfTimesThenWasRetrieved;
                         return function thenMethodForX(onFulfilled) {
+                            ++numberOfTimesThenWasRetrieved;
                             onFulfilled();
                         };
                     }


### PR DESCRIPTION
To detect whether an object is 'thenable', a Promise library needs to check whether 'then' is callable.
This check would be something like below:

```
if (obj && typeof obj.then === 'function') {
  // thenable
  obj.then(f1, f2);
}
```

In this case, 'then' will be referred to twice (numberOfTimesThenWasRetrieved === 2)
However, these test cases require numberOfTimesThenWasRetrieved to be 1.
I think numberOfTimesThenWasRetrieved must be the times 'then' is called rather than 'then' is referred to.
