### PR TITLE
Don't use ^ in package.json: breaks node 0.8

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     },
     "dependencies": {
         "mocha": "~1.21.4",
-        "sinon": "^1.10.3",
+        "sinon": ">=1.10.3 <1.11.0",
         "underscore": "~1.6.0"
     },
     "devDependencies": {


### PR DESCRIPTION
Heya,

Thanks for the great module. Small suggestion: latest version uses ^, which isn't supported in old versions of npm and node, and so breaks [some of my travis builds on node 0.8](https://travis-ci.org/LearnBoost/mongoose/jobs/49800412). I know I could just install a newer version of npm on top of old node but this change would make my life a lot easier :)