### PR TITLE
Fix:run npm install could error

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "main": "lib/programmaticRunner.js",
     "bin": "lib/cli.js",
     "files": [
-        "lib/",
+        "lib/"
     ],
     "scripts": {
         "lint": "jshint lib",


### PR DESCRIPTION
Hi ~ When I run npm install , I found have error, beacuse package.json file
have more comma . 
"files": [
  "lib/",
],