### PR TITLE
Upgrade packages (needed for Node.js 7 compatibility)

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,12 +18,12 @@
         "prepublish": "node ./scripts/generateTestFiles.js"
     },
     "dependencies": {
-        "mocha": "~1.21.4",
+        "mocha": "^2.5.3",
         "sinon": "^1.10.3",
-        "underscore": "~1.6.0"
+        "underscore": "^1.8.3"
     },
     "devDependencies": {
-        "jshint": "~2.4.4"
+        "jshint": "^2.9.2"
     },
     "browser": {
         "mocha": false


### PR DESCRIPTION
The version of mocha used so far relies on an outdated graceful-fs version
that prints deprecation messages in Node.js 6 and will stop working in
Node.js 7.