### PR TITLE
test that exotic thenable objects correctly return values

### DIFF
--- a/lib/tests/2.3.3.js
+++ b/lib/tests/2.3.3.js
@@ -134,7 +134,7 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                         get: function () {
                             ++numberOfTimesThenWasRetrieved;
                             return function thenMethodForX(onFulfilled) {
-                                onFulfilled();
+                                onFulfilled('correct return');
                             };
                         }
                     }
@@ -142,8 +142,9 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
+                promise.then(function (result) {
                     assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
+                    assert.strictEqual(result, 'correct return');
                     done();
                 });
             });
@@ -162,7 +163,7 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                         get: function () {
                             ++numberOfTimesThenWasRetrieved;
                             return function thenMethodForX(onFulfilled) {
-                                onFulfilled();
+                                onFulfilled('correct return');
                             };
                         }
                     }
@@ -170,8 +171,9 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
+                promise.then(function (result) {
                     assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
+                    assert.strictEqual(result, 'correct return');
                     done();
                 });
             });
@@ -191,7 +193,7 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     get: function () {
                         ++numberOfTimesThenWasRetrieved;
                         return function thenMethodForX(onFulfilled) {
-                            onFulfilled();
+                            onFulfilled('correct return');
                         };
                     }
                 });
@@ -200,8 +202,9 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
+                promise.then(function (result) {
                     assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
+                    assert.strictEqual(result, 'correct return');
                     done();
                 });
             });


### PR DESCRIPTION
my library was passing the tests but had a bug in it's implementation in that functions with a then method would not correctly resolve the value.  This updates the tests to correctly spot this edge case.