### PR TITLE
use mocha 1.21 which uses specific debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "promises-aplus-tests",
     "description": "Compliance test suite for Promises/A+",
     "keywords": ["promises", "promises-aplus"],
-    "version": "1.3.2",
+    "version": "1.3.3",
     "implements": ["Promises/A+ 1.0.0"],
     "author": "Domenic Denicola <domenic@domenicdenicola.com> (http://domenicdenicola.com)",
     "license": "WTFPL",
@@ -19,7 +19,7 @@
         "lint": "jshint lib"
     },
     "dependencies": {
-        "mocha": "~1.11.0",
+        "mocha": "~1.21",
         "sinon": "~1.7.3",
         "underscore": "~1.4.4"
     },


### PR DESCRIPTION
mocha before 1.21 depends on version '*' of the debug package, which cause problems when we do regression with `promises-tests` for backward compatibility, for example: https://github.com/kriskowal/q/pull/841