### PR TITLE
2.3.3: better handle failures

### DIFF
--- a/lib/tests/2.3.3.js
+++ b/lib/tests/2.3.3.js
@@ -103,19 +103,29 @@ function testCallingResolvePromiseFulfillsWith(yFactory, stringRepresentation, f
 
 function testCallingResolvePromiseRejectsWith(yFactory, stringRepresentation, rejectionReason) {
     testCallingResolvePromise(yFactory, stringRepresentation, function (promise, done) {
-        promise.then(null, function onPromiseRejected(reason) {
-            assert.strictEqual(reason, rejectionReason);
-            done();
-        });
+        promise.then(
+            function (value) {
+                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+            },
+            function onPromiseRejected(reason) {
+                assert.strictEqual(reason, rejectionReason);
+                done();
+            }
+        );
     });
 }
 
 function testCallingRejectPromiseRejectsWith(reason, stringRepresentation) {
     testCallingRejectPromise(reason, stringRepresentation, function (promise, done) {
-        promise.then(null, function onPromiseRejected(rejectionReason) {
-            assert.strictEqual(rejectionReason, reason);
-            done();
-        });
+        promise.then(
+            function (value) {
+                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+            },
+            function onPromiseRejected(rejectionReason) {
+                assert.strictEqual(rejectionReason, reason);
+                done();
+            }
+        );
     });
 }
 
@@ -142,10 +152,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
-                    assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
-                    done();
-                });
+                promise.then(
+                    function () {
+                        assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
+                        done();
+                    },
+                    function (reason) {
+                        done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                    }
+                );
             });
         });
 
@@ -170,10 +185,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
-                    assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
-                    done();
-                });
+                promise.then(
+                    function () {
+                        assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
+                        done();
+                    },
+                    function (reason) {
+                        done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                    }
+                );
             });
         });
 
@@ -200,10 +220,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
-                    assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
-                    done();
-                });
+                promise.then(
+                    function () {
+                        assert.strictEqual(numberOfTimesThenWasRetrieved, 1);
+                        done();
+                    },
+                    function (reason) {
+                        done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                    }
+                );
             });
         });
     });
@@ -223,10 +248,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
 
             describe("`e` is " + stringRepresentation, function () {
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, e);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, e);
+                            done();
+                        }
+                    );
                 });
             });
         }
@@ -252,9 +282,14 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
-                    done();
-                });
+                promise.then(
+                    function () {
+                        done();
+                    },
+                    function (reason) {
+                        done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                    }
+                );
             });
         });
 
@@ -281,9 +316,14 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
             }
 
             testPromiseResolution(xFactory, function (promise, done) {
-                promise.then(function () {
-                    done();
-                });
+                promise.then(
+                    function () {
+                        done();
+                    },
+                    function (reason) {
+                        done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                    }
+                );
             });
         });
 
@@ -368,10 +408,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -389,10 +434,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -412,10 +462,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -436,10 +491,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -460,10 +520,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -478,10 +543,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -499,10 +569,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -522,10 +597,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -540,10 +620,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -561,10 +646,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -584,10 +674,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, sentinel);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
 
@@ -632,10 +727,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -650,10 +750,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -671,10 +776,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -694,10 +804,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                 }
 
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(null, function (reason) {
-                        assert.strictEqual(reason, sentinel);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                        },
+                        function (reason) {
+                            assert.strictEqual(reason, sentinel);
+                            done();
+                        }
+                    );
                 });
             });
 
@@ -767,10 +882,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(function (value) {
-                            assert.strictEqual(value, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                assert.strictEqual(value, sentinel);
+                                done();
+                            },
+                            function (reason) {
+                                done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                            }
+                        );
                     });
                 });
 
@@ -790,10 +910,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(function (value) {
-                            assert.strictEqual(value, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                assert.strictEqual(value, sentinel);
+                                done();
+                            },
+                            function (reason) {
+                                done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                            }
+                        );
                     });
                 });
 
@@ -813,10 +938,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(null, function (reason) {
-                            assert.strictEqual(reason, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                            },
+                            function (reason) {
+                                assert.strictEqual(reason, sentinel);
+                                done();
+                            }
+                        );
                     });
                 });
 
@@ -831,10 +961,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(null, function (reason) {
-                            assert.strictEqual(reason, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                            },
+                            function (reason) {
+                                assert.strictEqual(reason, sentinel);
+                                done();
+                            }
+                        );
                     });
                 });
 
@@ -850,10 +985,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(function (value) {
-                            assert.strictEqual(value, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                assert.strictEqual(value, sentinel);
+                                done();
+                            },
+                            function (reason) {
+                                done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                            }
+                        );
                     });
                 });
 
@@ -869,10 +1009,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(null, function (reason) {
-                            assert.strictEqual(reason, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                            },
+                            function (reason) {
+                                assert.strictEqual(reason, sentinel);
+                                done();
+                            }
+                        );
                     });
                 });
             });
@@ -888,10 +1033,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(null, function (reason) {
-                            assert.strictEqual(reason, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                            },
+                            function (reason) {
+                                assert.strictEqual(reason, sentinel);
+                                done();
+                            }
+                        );
                     });
                 });
 
@@ -908,10 +1058,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(null, function (reason) {
-                            assert.strictEqual(reason, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                            },
+                            function (reason) {
+                                assert.strictEqual(reason, sentinel);
+                                done();
+                            }
+                        );
                     });
                 });
 
@@ -928,10 +1083,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
                     }
 
                     testPromiseResolution(xFactory, function (promise, done) {
-                        promise.then(null, function (reason) {
-                            assert.strictEqual(reason, sentinel);
-                            done();
-                        });
+                        promise.then(
+                            function (value) {
+                                done(new Error('promise fulfilled with ' + value + '; expected rejection'));
+                            },
+                            function (reason) {
+                                assert.strictEqual(reason, sentinel);
+                                done();
+                            }
+                        );
                     });
                 });
             });
@@ -952,10 +1112,15 @@ describe("2.3.3: Otherwise, if `x` is an object or function,", function () {
 
             describe("`then` is " + stringRepresentation, function () {
                 testPromiseResolution(xFactory, function (promise, done) {
-                    promise.then(function (value) {
-                        assert.strictEqual(value, x);
-                        done();
-                    });
+                    promise.then(
+                        function (value) {
+                            assert.strictEqual(value, x);
+                            done();
+                        },
+                        function (reason) {
+                            done(new Error('promise rejected with ' + reason + '; expected fulfillment'));
+                        }
+                    );
                 });
             });
         }


### PR DESCRIPTION
In node versions v10.0 and v10.1, these tests time out (as seen in es6-shim's tests [1](https://travis-ci.com/github/es-shims/es6-shim/jobs/218742353) [2](https://travis-ci.com/github/es-shims/es6-shim/jobs/218742354)), instead of failing quickly with a helpful message. By providing an explicit `done(err)` call in the failure path, this is addressed.