### PR TITLE
test: add a test about throw an error at a promise which has no `onRejected` to handle it.

### DIFF
--- a/lib/tests/2.2.7.js
+++ b/lib/tests/2.2.7.js
@@ -1,5 +1,6 @@
 "use strict";
 
+var expect = require("chai").expect;
 var assert = require("assert");
 var testFulfilled = require("./helpers/testThreeCases").testFulfilled;
 var testRejected = require("./helpers/testThreeCases").testRejected;
@@ -58,6 +59,26 @@ describe("2.2.7: `then` must return a promise: `promise2 = promise1.then(onFulfi
             testReason(reasons[stringRepresentation](), stringRepresentation);
         });
     });
+    
+    describe("2.2.7.2.2: If either `onFulfilled` or `onRejected` throws an exception `e`, and no next `then` to " +
+        "handle rejection and no `catch`, should throw a global exception `e`", function () {
+        specify("throw directly", function (done) {
+            class customError extends Error {
+                constructor() {
+                    super();
+                    this.name = 'customError';
+                }
+            }
+            process.once('unhandledRejection', (reason) => {
+                expect(reason).to.be.an.instanceOf(customError);
+                done()
+            });
+
+            adapter.resolved(1).then((res)=>{
+                throw new customError();
+            })
+        });
+    })
 
     describe("2.2.7.3: If `onFulfilled` is not a function and `promise1` is fulfilled, `promise2` must be fulfilled " +
              "with the same value.", function () {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
         "prepublish": "node ./scripts/generateTestFiles.js"
     },
     "dependencies": {
+        "chai": "^4.0.1",
         "mocha": "^2.5.3",
         "sinon": "^1.10.3",
         "underscore": "~1.8.3"


### PR DESCRIPTION
According to [2.2.7.2](https://promisesaplus.com/#point-42), `Promise` should reject with throwed exception `e`.
By using the origin Promise, we can find out that if there is no `onRejected` to handle it, `Process` will emit `unhandledRejection` and throw the `e` globally.
So I think there has a missed case.